### PR TITLE
Disabled the new DocLint feature in Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,22 @@
                     <target>1.6</target>
                 </configuration>
             </plugin>
+  			<plugin>
+  				<groupId>org.apache.maven.plugins</groupId>
+  				<artifactId>maven-javadoc-plugin</artifactId>
+  				<version>2.9</version>
+  				<executions>
+  					<execution>
+  						<id>attach-javadocs</id>
+  						<goals>
+  							<goal>jar</goal>
+  						</goals>
+  						<configuration>
+  							<additionalparam>-Xdoclint:none</additionalparam>
+  						</configuration>
+  					</execution>
+  				</executions>
+      		</plugin>
       </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -84,22 +84,22 @@
                     <target>1.6</target>
                 </configuration>
             </plugin>
-  			<plugin>
-  				<groupId>org.apache.maven.plugins</groupId>
-  				<artifactId>maven-javadoc-plugin</artifactId>
-  				<version>2.9</version>
-  				<executions>
-  					<execution>
-  						<id>attach-javadocs</id>
-  						<goals>
-  							<goal>jar</goal>
-  						</goals>
-  						<configuration>
-  							<additionalparam>-Xdoclint:none</additionalparam>
-  						</configuration>
-  					</execution>
-  				</executions>
-      		</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
       </plugins>
   </build>
 </project>


### PR DESCRIPTION
This is a quick fix that disables the new DocLint feature in Java 8.
Right now without this fix it is impossible to compile the library in Java 8.
